### PR TITLE
Add test to validate that `bin/setup` runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,28 @@ jobs:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@main
       - run: brew test-bot --only-tap-syntax
+   
+  validate-bin-setup:
+    name: "Validate that bin/setup runs successfully"
+    strategy:
+      matrix:
+        runner:
+          - macos-13 # intel
+          - macos-14 # arm
+          - ubuntu-22.04
+          - ubuntu-22.04-arm
+      fail-fast: false
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@main
+      - name: Set up Homebrew
+        run: |
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          echo "/home/linuxbrew/.linuxbrew/bin" >> $GITHUB_PATH
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+      - name: Run bin/setup
+        run: |
+          bin/setup
 
   # list_edited_formulas:
   # build_edited_formulas:


### PR DESCRIPTION
I had trouble running `bin/setup` on Ubuntu 22.04 so I added this test to validate that `bin/setup` worked on all of the platforms. It does not, but now we have tests to show that :smile: 