### PR TITLE
fix a new failure in ruby 0.49 on macOS

### DIFF
--- a/Formula/rv-ruby@0.49.rb
+++ b/Formula/rv-ruby@0.49.rb
@@ -2,7 +2,7 @@ require File.expand_path("../Abstract/portable-formula", __dir__)
 
 class RvRubyAT049 < Formula
   prepend PortableFormulaMixin
-
+  keg_only "portable formulae are keg-only"
   desc "A working upgrade of the oldest extant ruby version"
   homepage "https://github.com/sampersand/ruby-0.49"
   version "0.49"

--- a/cmd/rv-package.rb
+++ b/cmd/rv-package.rb
@@ -102,7 +102,7 @@ module Homebrew
 
           json = File.read j
           json.gsub! "#{name}--", "ruby-"
-          json.gsub! /-HEAD-[a-f0-9]+/, "-dev"
+          json.gsub!(/-HEAD-[a-f0-9]+/, "-dev")
           json.gsub!(".sequoia.", ".ventura.")
           json.gsub!(".bottle.", yjit_tag)
           json.gsub! ERB::Util.url_encode(name), "ruby"
@@ -116,7 +116,7 @@ module Homebrew
 
         Dir.glob("#{name}*").each do |f|
           r = f.gsub("#{name}--", "ruby-")
-          r = r.gsub /-HEAD-[a-f0-9]+/, "-dev"
+          r = r.gsub(/-HEAD-[a-f0-9]+/, "-dev")
           r = r.gsub(".sequoia.", ".ventura.")
           r = r.gsub(".bottle.", yjit_tag)
           FileUtils.mv f, r


### PR DESCRIPTION
because the 0.49 formula is not marked keg_only, homebrew tries to link
it during install -- and linking fails because GitHub Action runners
apparently have ruby installed via homebrew now, so linking errors.