### PR TITLE
ci: add zizmor, pin Actions to SHAs, harden CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,3 @@
-# This file is synced from the `.github` repository, do not modify it directly.
----
 version: 2
 multi-ecosystem-groups:
   all:
@@ -17,7 +15,7 @@ updates:
   allow:
   - dependency-type: all
   cooldown:
-    default-days: 1
+    default-days: 7
     include:
     - "*"
 

--- a/.github/workflows/build-alpine.yml
+++ b/.github/workflows/build-alpine.yml
@@ -46,9 +46,11 @@ jobs:
           persist-credentials: false
 
       - name: Build Ruby
+        env:
+          FORMULA: ${{ inputs.formula }}
         run: |
-          docker run --rm -v "$GITHUB_WORKSPACE:/src" -w /src ${{ env.ALPINE_IMAGE }} sh -c '
-            bin/package-alpine "${{ inputs.formula }}"
+          docker run --rm -v "$GITHUB_WORKSPACE:/src" -w /src -e FORMULA "$ALPINE_IMAGE" sh -c '
+            bin/package-alpine "$FORMULA"
           '
 
       - name: Upload artifact

--- a/.github/workflows/build-alpine.yml
+++ b/.github/workflows/build-alpine.yml
@@ -41,7 +41,9 @@ jobs:
     # GitHub's JS-based actions (checkout, upload-artifact) don't support
     # Alpine containers on ARM runners.
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Build Ruby
         run: |

--- a/.github/workflows/build-alpine.yml
+++ b/.github/workflows/build-alpine.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Generate build attestation
         if: ${{ hashFiles('rubies/*.tar.gz') != '' }}
-        uses: actions/attest@v4.1.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: rubies/*.tar.gz
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
           fi
 
       # Static gem extensions typically require the same Ruby version available already
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@4c56a21280b36d862b5fc31348f463d60bdc55d5 # v1.301.0
         id: setup-ruby
         if: ${{ env.SETUP_RUBY_VERSION != '' }}
         with:
@@ -81,7 +81,7 @@ jobs:
           path: ${{ github.workspace }}/rubies
 
       - name: Generate build attestation
-        uses: actions/attest@v4.1.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: rubies/*.tar.gz
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,10 @@ jobs:
           persist-credentials: false
 
       - name: Get version for setup-ruby
+        env:
+          FORMULA: ${{ inputs.formula }}
         run: |
-          SETUP_RUBY_VERSION=${{ inputs.formula }}
+          SETUP_RUBY_VERSION="${FORMULA}"
           SETUP_RUBY_VERSION=${SETUP_RUBY_VERSION//rv-ruby}
           SETUP_RUBY_VERSION=${SETUP_RUBY_VERSION//@}
           if [[ "$SETUP_RUBY_VERSION" == "3.2."* ]]; then
@@ -68,13 +70,15 @@ jobs:
       - name: Build rv Ruby
         env:
           HOMEBREW_NO_INSTALL_CLEANUP: 1
+          SETUP_RUBY_PREFIX: ${{ steps.setup-ruby.outputs.ruby-prefix }}
+          FORMULA: ${{ inputs.formula }}
         run: |
-          if [[ -n "${{ steps.setup-ruby.outputs.ruby-prefix }}" ]]; then
-            export HOMEBREW_BASERUBY="${{ steps.setup-ruby.outputs.ruby-prefix }}/bin/ruby"
+          if [[ -n "$SETUP_RUBY_PREFIX" ]]; then
+            export HOMEBREW_BASERUBY="${SETUP_RUBY_PREFIX}/bin/ruby"
           fi
           mkdir -p rubies/
           cd rubies
-          brew rv-package --verbose ${{ inputs.formula }}
+          brew rv-package --verbose "$FORMULA"
 
       - name: Upload rv Ruby
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -88,11 +92,13 @@ jobs:
           subject-path: rubies/*.tar.gz
 
       - name: Test Portable Ruby
+        env:
+          FORMULA: ${{ inputs.formula }}
         run: |
           mkdir -p rv-ruby/
           tar --strip-components 2 -C rv-ruby -xf rubies/*.tar.gz
           export PATH="${PWD}/rv-ruby/bin:${PATH}"
-          if [[ "${{ inputs.formula }}" == "rv-ruby@0.49" ]]; then
+          if [[ "$FORMULA" == "rv-ruby@0.49" ]]; then
             ruby --version
           else
             ruby --version --yjit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,9 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Get version for setup-ruby
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,13 @@ jobs:
       - run: date
       - run: date +%Y%m%d
       - id: setup
+        env:
+          FORMULA_FILTER: ${{ inputs.formula }}
         run: |
           list=$(ls Formula/rv-ruby* | jq --raw-input | jq --slurp --compact-output 'map(. |= .[8:-3])')
-          if [[ -n "${{ inputs.formula }}" ]]; then
+          if [[ -n "$FORMULA_FILTER" ]]; then
             # if we passed a string, only build matches
-            list=$(echo $list | jq --compact-output 'map(select(. | contains("${{ inputs.formula }}")))')
+            list=$(echo "$list" | jq --compact-output --arg f "$FORMULA_FILTER" 'map(select(. | contains($f)))')
           else
             # without a filter, build all but rv-ruby-dev
             list=${list/'"'rv-ruby-dev'"',/}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,9 @@ jobs:
       formulas: ${{ steps.setup.outputs.formulas }}
       date: ${{ steps.setup.outputs.date }}
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - run: date
       - run: date +%Y%m%d
       - id: setup
@@ -83,7 +85,9 @@ jobs:
     env:
       TAG: ${{ needs.setup.outputs.date }}
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Homebrew
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Generate release artifact provenance attestations
         if: ${{ inputs.formula == '' }}
-        uses: actions/attest@v4.1.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-checksums: rubies/SHA256SUMS
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,25 @@
+name: GitHub Actions security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        Homebrew/actions/*: ref-pin


### PR DESCRIPTION
## Summary

Mirrors spinel-coop/rv#578 and spinel-coop/rv#593 for rv-ruby.

## Changes

- Add a dedicated [zizmor](https://github.com/zizmorcore/zizmor) workflow for static analysis of GitHub Actions workflows
- Pin all third-party actions to commit SHAs with version comments
  - Unpinned refs are vulnerable to being moved or force-pushed to commits with malicious changes if the target action repo is compromised.
    - E.g., the [tj-actions/changed-files supply chain attack](https://github.com/advisories/GHSA-mrrh-fwg8-r2c3) involved an attacker moving version tags to point at a malicious commit, leaking CI secrets from thousands of repos. Repos that had pinned to a commit SHA [were unaffected](https://www.wiz.io/blog/github-action-tj-actions-changed-files-supply-chain-attack-cve-2025-30066).
  - These pins are strictly no-op changes, not version bumps; each SHA is what the floating tag already resolves to today (e.g. `ruby/setup-ruby@v1` -> v1.301.0)
  - Move `actions/checkout@main` -> `checkout@<sha> # v6.0.2`. `@main` is unstable and could pick up any unreleased commit between tags
  - Add `.github/zizmor.yml` allowing `Homebrew/actions/*` as `ref-pin`. Those live in a monorepo with no per-action tags; Homebrew pins them to `@main` in their own workflows for the same reason
- Add `persist-credentials: false` to all `actions/checkout` usages
- Fix a template-injection finding in `release.yml` by threading inputs through `env:` rather than interpolating them into the shell
- Dependabot
  - Bump `cooldown.default-days` 1 -> 7 (safer window against supply-chain compromises) to satisfy zizmor's `dependabot-cooldown` audit
  - Drop the `# synced from the .github repository` header, which was copy-pasted from Homebrew infra that doesn't exist in this fork

## Maintenance

- Dependabot will update SHA-pinned actions and their version comments in tandem
- zizmor's `ref-version-mismatch` audit (enabled by default) verifies that version comments actually match the pinned SHA, so any comment drift will be caught in CI
