### PR TITLE
Reverse the bottle-detection logic

### DIFF
--- a/cmd/rv-package.rb
+++ b/cmd/rv-package.rb
@@ -60,19 +60,19 @@ module Homebrew
 
           begin
             # Install build deps (but not static-linked deps) from bottles, to save compilation time
-            bottled_dep_allowlist = /\A(?:glibc@|linux-headers@|ruby@|rustup|autoconf|pkgconf|bison)/
+            static_deps = /portable-/
             deps = Dependency.expand(Formula[name], cache_key: "rv-package-#{name}") do |_dependent, dep|
               next prune if dep.test? || dep.optional?
               next prune if dep.name == "rustup" && args.without_yjit?
 
-              next unless bottled_dep_allowlist.match?(dep.name)
+              next if static_deps.match?(dep.name)
 
               keep_but_prune_recursive_deps
             end.map(&:name)
 
-            bottled_deps, deps = deps.partition { |dep| bottled_dep_allowlist.match?(dep) }
+            deps, bottled_deps = deps.partition { |dep| static_deps.match?(dep) }
             puts "Bottled deps: #{bottled_deps.inspect}"
-            puts "Other deps: #{deps.inspect}"
+            puts "Compiled deps: #{deps.inspect}"
 
             quiet_system HOMEBREW_BREW_FILE, "install", *verbose, *bottled_deps if bottled_deps.any?
 


### PR DESCRIPTION
Instead of allow-listing bottles, use bottles for everything that _isn't_ a `portable-` formula. Experimentally, this is much better at handling changes to Homebrew, changes to formula dependencies, and changes to what GitHub chooses to ship already installed on their GHA runners.

Fixes the daily ruby-dev build, as seen in https://github.com/spinel-coop/rv-ruby-dev/actions/runs/26339446575.