### PR TITLE
Ruby 3.4.10

### DIFF
--- a/Formula/rv-ruby@3.4.10.rb
+++ b/Formula/rv-ruby@3.4.10.rb
@@ -1,0 +1,6 @@
+require File.expand_path("../Abstract/rv-ruby-34", __dir__)
+
+class RvRubyAT3410 < RvRuby34
+  url "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.10.tar.gz"
+  sha256 "ecee2d072a14f2d14347dd56dfd8fe5c3130abf5117bfaacbda0f4ef9cc429ec"
+end


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2026/06/30/ruby-3-4-10-released/