### PR TITLE
Ruby 3.4.10 plus fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,8 @@ jobs:
         runner:
           - macos-15-intel # intel
           - macos-14 # arm
-          - ubuntu-22.04
-          - ubuntu-22.04-arm
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,7 @@ jobs:
           echo "/home/linuxbrew/.linuxbrew/bin" >> $GITHUB_PATH
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           brew tap spinel-coop/rv-ruby .
+          brew trust spinel-coop/rv-ruby
 
       - name: Checkout branch
         run: git checkout "${GITHUB_REF_NAME}"

--- a/Abstract/rv-ruby.rb
+++ b/Abstract/rv-ruby.rb
@@ -16,7 +16,7 @@ class RvRuby < Formula
 
       # This regex restricts matching to versions other than X.Y.0.
       livecheck do
-        formula "ruby"
+        url "https://www.ruby-lang.org/en/downloads/releases/"
         regex(/href=.*?ruby[._-]v?(\d+\.\d+\.(?:(?!0)\d+)(?:\.\d+)*)\.t/i)
       end
 

--- a/Formula/rv-ruby@3.4.10.rb
+++ b/Formula/rv-ruby@3.4.10.rb
@@ -1,0 +1,6 @@
+require File.expand_path("../Abstract/rv-ruby-34", __dir__)
+
+class RvRubyAT3410 < RvRuby34
+  url "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.10.tar.gz"
+  sha256 "ecee2d072a14f2d14347dd56dfd8fe5c3130abf5117bfaacbda0f4ef9cc429ec"
+end


### PR DESCRIPTION
Adds Ruby 3.4.10, fixes the release task for the new `brew trust` situation, and fixes the build on Linux where Homebrew started adding their own glibc recently if yours is too old.

Our static Rubies will now only work on Ubuntu 24.04-era Linux and newer. If that's a problem, we'd like to hear from you, and we can try to investigate other options for supporting older versions of glibc.