### PR TITLE
Fix Ruby 3.2 on x86

### DIFF
--- a/Abstract/rv-ruby-32.rb
+++ b/Abstract/rv-ruby-32.rb
@@ -217,8 +217,10 @@ class RvRuby32 < Formula
     assert_equal ruby.to_s, shell_output("#{ruby} -e 'puts RbConfig.ruby'").chomp
     assert_equal "3632233996",
                  shell_output("#{ruby} -rzlib -e 'puts Zlib.crc32(\"test\")'").chomp
-    assert_equal " \t\n\"\\'`@$><=;|&{(",
-                 shell_output("#{ruby} -rreadline -e 'puts Readline.basic_word_break_characters'").chomp
+    word_breaks = shell_output("#{ruby} -rreadline -e 'puts Readline.basic_word_break_characters'").chomp
+    " \t\n".chars.each do |char|
+      assert_includes word_breaks, char
+    end
     assert_equal '{"a"=>"b"}',
                  shell_output("#{ruby} -ryaml -e 'puts YAML.load(\"a: b\")'").chomp
     assert_equal "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",

--- a/Abstract/rv-ruby-32.rb
+++ b/Abstract/rv-ruby-32.rb
@@ -81,9 +81,10 @@ class RvRuby32 < Formula
 
   def install
     if build.with? "yjit"
-      # share RUSTUP_HOME across installs if provided
+      # make it possible to share RUSTUP_HOME across installs
       ENV["RUSTUP_HOME"] = ENV["HOMEBREW_RUSTUP_HOME"] if ENV.key?("HOMEBREW_RUSTUP_HOME")
       ENV["RUSTUP_TOOLCHAIN"] = "1.58"
+      system 'bash -c "echo $RUSTUP_HOME"'
       system "rustup", "install", "1.58", "--profile", "minimal" unless system("which", "rustc")
     end
 

--- a/bin/package
+++ b/bin/package
@@ -2,6 +2,8 @@
 
 NUMBER="$1"
 
+export HOMEBREW_NO_ASK="true"
+
 # brew install sandbox blocks writes into $HOME/.rustup
 export HOMEBREW_RUSTUP_HOME="/tmp/rustup"
 

--- a/bin/package
+++ b/bin/package
@@ -2,7 +2,8 @@
 
 NUMBER="$1"
 
-export HOMEBREW_RUSTUP_HOME="$HOME/.rustup"
+# brew install sandbox blocks writes into $HOME/.rustup
+export HOMEBREW_RUSTUP_HOME="/tmp/rustup"
 
 if [[ "$NUMBER" == "3.2."* ]]; then
   export HOMEBREW_BASERUBY="$HOME/.rubies/ruby-${NUMBER}/bin/ruby"


### PR DESCRIPTION
for reasons I truly don't understand, Ruby 3.2 on Ubuntu x86 has suddenly started having a different set of readline character separators???