### PR TITLE
handle AR=gcc-ar as well as gcc-ar-11

### DIFF
--- a/Abstract/rv-ruby-32.rb
+++ b/Abstract/rv-ruby-32.rb
@@ -190,8 +190,8 @@ class RvRuby32 < Formula
       inreplace lib/"ruby/#{abi_version}/#{abi_arch}/rbconfig.rb" do |s|
         s.gsub! ENV.cxx, "c++"
         s.gsub! ENV.cc, "cc"
-        # Change e.g. `CONFIG["AR"] = "gcc-ar-11"` to `CONFIG["AR"] = "ar"`
-        s.gsub!(/(CONFIG\[".+"\] = )"gcc-(.*)-\d+"/, '\\1"\\2"', audit_result: false)
+        # Change e.g. `CONFIG["AR"] = "gcc-ar-11"` to `CONFIG["AR"] = "ar"`.
+        s.gsub!(/(CONFIG\[".+"\] = )"gcc-(.*)(-\d+)?"/, '\\1"\\2"')
         # C++ compiler might have been disabled because we break it with glibc@* builds
         s.sub!(/(CONFIG\["CXX"\] = )"false"/, '\\1"c++"') if build.without? "yjit"
       end

--- a/Abstract/rv-ruby-33.rb
+++ b/Abstract/rv-ruby-33.rb
@@ -178,8 +178,8 @@ class RvRuby33 < Formula
       inreplace lib/"ruby/#{abi_version}/#{abi_arch}/rbconfig.rb" do |s|
         s.gsub! ENV.cxx, "c++"
         s.gsub! ENV.cc, "cc"
-        # Change e.g. `CONFIG["AR"] = "gcc-ar-11"` to `CONFIG["AR"] = "ar"`
-        s.gsub!(/(CONFIG\[".+"\] = )"gcc-(.*)-\d+"/, '\\1"\\2"', audit_result: false)
+        # Change e.g. `CONFIG["AR"] = "gcc-ar-11"` to `CONFIG["AR"] = "ar"`.
+        s.gsub!(/(CONFIG\[".+"\] = )"gcc-(.*)(-\d+)?"/, '\\1"\\2"')
         # C++ compiler might have been disabled because we break it with glibc@* builds
         s.sub!(/(CONFIG\["CXX"\] = )"false"/, '\\1"c++"') if build.without? "yjit"
       end

--- a/Abstract/rv-ruby-34.rb
+++ b/Abstract/rv-ruby-34.rb
@@ -178,8 +178,8 @@ class RvRuby34 < Formula
       inreplace lib/"ruby/#{abi_version}/#{abi_arch}/rbconfig.rb" do |s|
         s.gsub! ENV.cxx, "c++"
         s.gsub! ENV.cc, "cc"
-        # Change e.g. `CONFIG["AR"] = "gcc-ar-11"` to `CONFIG["AR"] = "ar"`
-        s.gsub!(/(CONFIG\[".+"\] = )"gcc-(.*)-\d+"/, '\\1"\\2"', audit_result: false)
+        # Change e.g. `CONFIG["AR"] = "gcc-ar-11"` to `CONFIG["AR"] = "ar"`.
+        s.gsub!(/(CONFIG\[".+"\] = )"gcc-(.*)(-\d+)?"/, '\\1"\\2"')
         # C++ compiler might have been disabled because we break it with glibc@* builds
         s.sub!(/(CONFIG\["CXX"\] = )"false"/, '\\1"c++"') if build.without? "yjit"
       end

--- a/Abstract/rv-ruby.rb
+++ b/Abstract/rv-ruby.rb
@@ -173,10 +173,11 @@ class RvRuby < Formula
     if OS.linux?
       # Don't restrict to a specific GCC compiler binary we used (e.g. gcc-5).
       inreplace lib/"ruby/#{abi_version}/#{abi_arch}/rbconfig.rb" do |s|
-        s.gsub! ENV.cxx, "c++"
-        s.gsub! ENV.cc, "cc"
-        # Change e.g. `CONFIG["AR"] = "gcc-ar-11"` to `CONFIG["AR"] = "ar"`.
-        s.gsub!(/(CONFIG\[".+"\] = )"gcc-(.*)-\d+"/, '\\1"\\2"', audit_result: false)
+        # Change e.g. `CONFIG["AR"] = "gcc-ar-11"` or "gcc-ar" to `CONFIG["AR"] = "ar"`.
+        s.gsub!(/(CONFIG\[".+"\] = )"gcc-(\w+)(-\d+)?"/, '\\1"\\2"')
+        # Change other instances of e.g. "gcc" to be generic
+        s.gsub!(ENV.cxx, "c++")
+        s.gsub!(ENV.cc, "cc")
         # C++ compiler might have been disabled because we break it with glibc@* builds
         s.sub!(/(CONFIG\["CXX"\] = )"false"/, '\\1"c++"') if build.without?("yjit") && build.without?("zjit")
       end


### PR DESCRIPTION
Seems like GitHub Actions recently changed their `gcc` from `gcc-ar-15` to `gcc-ar`, and the regular expression that updated RbConfig didn't know how to handle it. This un-breaks installing gems that need to compile, like nokogiri.