### PR TITLE
fix rv builds on the latest brew HEAD

### DIFF
--- a/cmd/rv-package.rb
+++ b/cmd/rv-package.rb
@@ -4,10 +4,14 @@
 require "abstract_command"
 require "development_tools"
 require "dependency"
+require "system_command"
 
 module Homebrew
   module Cmd
     class RvPackageCmd < AbstractCommand
+      # Homebrew/brew#15069d12a0 removed Kernel#safe_system in favour of this mixin
+      include SystemCommand::Helpers if defined?(SystemCommand::Helpers)
+
       cmd_args do
         usage_banner <<~EOS
           `rv-package` <formulae>
@@ -51,7 +55,7 @@ module Homebrew
         flags << "--without-yjit" if args.without_yjit?
 
         # If test-bot cleanup is performed and auto-updates are disabled, this might not already be installed.
-        unless DevelopmentTools.ca_file_handles_most_https_certificates?
+        unless DevelopmentTools.curl_handles_most_https_certificates?
           safe_system HOMEBREW_BREW_FILE, "install", "ca-certificates"
         end
 

--- a/cmd/rv-upload.rb
+++ b/cmd/rv-upload.rb
@@ -37,7 +37,9 @@ module Homebrew
         json_files = Dir["ruby-*.json"]
         odie "No bottle JSON files found in the current working directory" if json_files.blank?
 
-        Homebrew.install_bundler_gems!(groups: ["pr_upload"])
+        # Homebrew/brew#37b53635ec moved `install_bundler_gems!` to `Utils::GemSetup`
+        gem_setup = defined?(Utils::GemSetup) ? Utils::GemSetup : Homebrew
+        gem_setup.install_bundler_gems!(groups: ["pr_upload"])
 
         bottles_hash = bottles_hash_from_json_files(json_files, args)
 


### PR DESCRIPTION
handle breaking API changes, trying to support both the last tagged release (macOS runners) and the latest commit (linux runners)